### PR TITLE
increase `ulimit` for cutadapt

### DIFF
--- a/src/pipecraft-core/service_scripts/demux_paired_end_data.sh
+++ b/src/pipecraft-core/service_scripts/demux_paired_end_data.sh
@@ -49,6 +49,9 @@ output_dir=$"/input/demultiplex_out"
 #python module for assigning sample names as based on indexes file
 run_python_module=$"python3 /scripts/submodules/assign_sample_names.demuxModule.py $indexes_file"
 
+# Increase the number of open files limit
+ulimit -S -n 6000
+
 #############################
 ### Start of the workflow ###
 #############################

--- a/src/pipecraft-core/service_scripts/demux_single_end_data.sh
+++ b/src/pipecraft-core/service_scripts/demux_single_end_data.sh
@@ -41,6 +41,9 @@ source /scripts/submodules/framework.functions.sh
 #output dir
 output_dir=$"/input/demultiplex_out"
 
+# Increase the number of open files limit
+ulimit -S -n 6000
+
 #############################
 ### Start of the workflow ###
 #############################


### PR DESCRIPTION
Demultiplexing fails with `ERROR: [Errno 24] Too many open files`

<img width="1448" height="570" alt="image" src="https://github.com/user-attachments/assets/b323d1a6-a866-4708-9436-0d91a8a58168" />

This is related to the number of open files allowed for a user. 
E.g., for 24 forward and 24 reverse adapters and paired-end data, you need about 25252=1250 file descriptors, plus a couple for communication between each process ([ref](https://github.com/marcelm/cutadapt/issues/320#issuecomment-874341730)).
The default `ulimit` is 1024.