### PR TITLE
macOS: add zip target for electron-updater auto-update

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -57,6 +57,12 @@ module.exports = {
               // GitHub runner hdiutil "Resource busy" when producing arm64 + x64 images).
               arch: ["universal"],
             },
+            {
+              // Required by electron-updater for macOS auto-updates: it cannot
+              // update from a .dmg, only from a zipped .app bundle.
+              target: "zip",
+              arch: ["universal"],
+            },
           ],
           icon: "build/icon.icns", 
           hardenedRuntime: true,      // Required for macOS 10.15+ (Catalina)


### PR DESCRIPTION
## Summary
- Adds a universal macOS **zip** build target alongside the existing dmg target in `vue.config.js`.
- `electron-updater` on macOS cannot apply updates from a `.dmg`; it requires a zipped `.app` bundle.
- Without the zip, `latest-mac.yml` only lists the dmg and auto-updates fail with "ZIP file not provided".

## Test plan
- [ ] Run macOS release build and confirm both `.dmg` and `.zip` artifacts are produced.
- [ ] Verify `latest-mac.yml` includes the zip asset.
- [ ] Smoke-test in-app auto-update on macOS.
